### PR TITLE
Proposal: expose a reInit() action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.9] - 2017-11-23
+
+- Added `reInit()` method to allow for runtime plugin reset
+
 ## [1.2.8] - 2017-10-13
 
 - [Android] fixing NPE when calling close right after unwatch and stop right after unregister

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ Closes the service browser and stops watching.
 zeroconf.close()
 ```
 
+#### `reInit(success, failure)`
+Re-initializes the entire plugin, which resets the browsers and services. Use this if the WiFi network has changed while the app is running.
+
+```javascript
+zeroconf.reInit()
+```
+
 ## Credits
 
 #### Android

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-zeroconf",
-    "version": "1.2.8",
+    "version": "1.2.9",
     "description": "Cordova ZeroConf plugin",
     "cordova": {
         "id": "cordova-plugin-zeroconf",
@@ -29,6 +29,10 @@
     "author": {
         "name": "Sylvain Bréjeon",
         "url": "https://github.com/becvert"
+    },
+    "contributors": {
+        "name": "Eric McNiece",
+        "url": "https://github.com/emcniece"
     },
     "license": "MIT",
     "bugs": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-zeroconf"
-    version="1.2.8">
+    version="1.2.9">
 
     <name>ZeroConf</name>
     <description>ZeroConf plugin for Cordova/Phonegap</description>

--- a/src/android/net/becvert/cordova/ZeroConf.java
+++ b/src/android/net/becvert/cordova/ZeroConf.java
@@ -62,6 +62,10 @@ public class ZeroConf extends CordovaPlugin {
     public static final String ACTION_UNWATCH = "unwatch";
     public static final String ACTION_CLOSE = "close";
 
+    // Re-init
+    public static final String ACTION_INIT = "init";
+    public static final String ACTION_DESTROY = "destroy";
+
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
@@ -135,6 +139,8 @@ public class ZeroConf extends CordovaPlugin {
             lock.release();
             lock = null;
         }
+
+        Log.v(TAG, "Destroyed");
     }
 
     @Override
@@ -329,6 +335,43 @@ public class ZeroConf extends CordovaPlugin {
             } else {
                 callbackContext.success();
             }
+
+        } else if (ACTION_INIT.equals(action)) {
+            Log.e(TAG, "Initializing");
+            
+            cordova.getThreadPool().execute(new Runnable() {
+
+                @Override
+                public void run() {
+                    try {
+                        initialize(cordova, webView);
+                        callbackContext.success();
+
+                    } catch (IOException e) {
+                        Log.e(TAG, e.getMessage(), e);
+                        callbackContext.error("Error: " + e.getMessage());
+                    }
+                }
+            });
+
+        } else if (ACTION_DESTROY.equals(action)) {
+            Log.e(TAG, "Destroying");
+
+            cordova.getThreadPool().execute(new Runnable() {
+
+                @Override
+                public void run() {
+                    try {
+                        onDestroy();
+                        callbackContext.success();
+
+                    } catch (IOException e) {
+                        Log.e(TAG, e.getMessage(), e);
+                        callbackContext.error("Error: " + e.getMessage());
+                    }
+                }
+            });
+
 
         } else {
             Log.e(TAG, "Invalid action: " + action);

--- a/src/android/net/becvert/cordova/ZeroConf.java
+++ b/src/android/net/becvert/cordova/ZeroConf.java
@@ -61,10 +61,8 @@ public class ZeroConf extends CordovaPlugin {
     public static final String ACTION_WATCH = "watch";
     public static final String ACTION_UNWATCH = "unwatch";
     public static final String ACTION_CLOSE = "close";
-
-    // Re-init
-    public static final String ACTION_INIT = "init";
-    public static final String ACTION_DESTROY = "destroy";
+    // Re-initialize
+    public static final String ACTION_INIT = "reInit";
 
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
@@ -337,41 +335,18 @@ public class ZeroConf extends CordovaPlugin {
             }
 
         } else if (ACTION_INIT.equals(action)) {
-            Log.e(TAG, "Initializing");
-            
-            cordova.getThreadPool().execute(new Runnable() {
-
-                @Override
-                public void run() {
-                    try {
-                        initialize(cordova, webView);
-                        callbackContext.success();
-
-                    } catch (IOException e) {
-                        Log.e(TAG, e.getMessage(), e);
-                        callbackContext.error("Error: " + e.getMessage());
-                    }
-                }
-            });
-
-        } else if (ACTION_DESTROY.equals(action)) {
-            Log.e(TAG, "Destroying");
+            Log.e(TAG, "Re-Initializing");
 
             cordova.getThreadPool().execute(new Runnable() {
-
                 @Override
                 public void run() {
-                    try {
-                        onDestroy();
-                        callbackContext.success();
+                    onDestroy();
+                    initialize(cordova, webView);
+                    callbackContext.success();
 
-                    } catch (IOException e) {
-                        Log.e(TAG, e.getMessage(), e);
-                        callbackContext.error("Error: " + e.getMessage());
-                    }
+                    Log.e(TAG, "Re-Initialization complete");
                 }
             });
-
 
         } else {
             Log.e(TAG, "Invalid action: " + action);

--- a/src/android/net/becvert/cordova/ZeroConf.java
+++ b/src/android/net/becvert/cordova/ZeroConf.java
@@ -62,7 +62,7 @@ public class ZeroConf extends CordovaPlugin {
     public static final String ACTION_UNWATCH = "unwatch";
     public static final String ACTION_CLOSE = "close";
     // Re-initialize
-    public static final String ACTION_INIT = "reInit";
+    public static final String ACTION_REINIT = "reInit";
 
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
@@ -334,7 +334,7 @@ public class ZeroConf extends CordovaPlugin {
                 callbackContext.success();
             }
 
-        } else if (ACTION_INIT.equals(action)) {
+        } else if (ACTION_REINIT.equals(action)) {
             Log.e(TAG, "Re-Initializing");
 
             cordova.getThreadPool().execute(new Runnable() {

--- a/src/ios/ZeroConf.swift
+++ b/src/ios/ZeroConf.swift
@@ -1,31 +1,31 @@
 import Foundation
 
 @objc(ZeroConf) public class ZeroConf : CDVPlugin  {
-    
+
     fileprivate var publishers: [String: Publisher]!
     fileprivate var browsers: [String: Browser]!
-    
+
     override public func pluginInitialize() {
         publishers  = [:]
         browsers = [:]
     }
-    
+
     override public func onAppTerminate() {
         for (_, publisher) in publishers {
             publisher.destroy()
         }
         publishers.removeAll()
-        
+
         for (_, browser) in browsers {
             browser.destroy();
         }
         browsers.removeAll()
     }
-    
+
     public func getHostname(_ command: CDVInvokedUrlCommand) {
-        
+
         let hostname = Hostname.get() as String
-        
+
         #if DEBUG
             print("ZeroConf: hostname \(hostname)")
         #endif
@@ -35,16 +35,16 @@ import Foundation
     }
 
     public func register(_ command: CDVInvokedUrlCommand) {
-        
+
         let type = command.argument(at: 0) as! String
         let domain = command.argument(at: 1) as! String
         let name = command.argument(at: 2) as! String
         let port = command.argument(at: 3) as! Int
-        
+
         #if DEBUG
             print("ZeroConf: register \(name + "." + type + domain)")
         #endif
-        
+
         var txtRecord: [String: Data]?
         if let dict = command.arguments[4] as? [String: String] {
             txtRecord = [:]
@@ -52,87 +52,87 @@ import Foundation
                 txtRecord?[key] = value.data(using: String.Encoding.utf8)
             }
         }
-        
+
         let publisher = Publisher(withDomain: domain, withType: type, withName: name, withPort: port, withTxtRecord: txtRecord, withCallbackId: command.callbackId)
         publisher.commandDelegate = commandDelegate
         publisher.register()
         publishers[name + "." + type + domain] = publisher
-    
+
     }
-    
+
     public func unregister(_ command: CDVInvokedUrlCommand) {
-        
+
         let type = command.argument(at: 0) as! String
         let domain = command.argument(at: 1) as! String
         let name = command.argument(at: 2) as! String
-        
+
         #if DEBUG
             print("ZeroConf: unregister \(name + "." + type + domain)")
         #endif
-        
+
         if let publisher = publishers[name + "." + type + domain] {
             publisher.unregister();
             publishers.removeValue(forKey: name + "." + type + domain)
         }
-        
+
     }
-    
+
     public func stop(_ command: CDVInvokedUrlCommand) {
         #if DEBUG
             print("ZeroConf: stop")
         #endif
-        
+
         for (_, publisher) in publishers {
             publisher.unregister()
         }
         publishers.removeAll()
     }
-    
+
     public func watch(_ command: CDVInvokedUrlCommand) {
-        
+
         let type = command.argument(at: 0) as! String
         let domain = command.argument(at: 1) as! String
-        
+
         #if DEBUG
             print("ZeroConf: watch \(type + domain)")
         #endif
-        
+
         let browser = Browser(withDomain: domain, withType: type, withCallbackId: command.callbackId)
         browser.commandDelegate = commandDelegate
         browser.watch()
         browsers[type + domain] = browser
-        
+
     }
-    
+
     public func unwatch(_ command: CDVInvokedUrlCommand) {
-        
+
         let type = command.argument(at: 0) as! String
         let domain = command.argument(at: 1) as! String
-        
+
         #if DEBUG
             print("ZeroConf: unwatch \(type + domain)")
         #endif
-        
+
         if let browser = browsers[type + domain] {
             browser.unwatch();
             browsers.removeValue(forKey: type + domain)
         }
-        
+
     }
-    
+
     public func close(_ command: CDVInvokedUrlCommand) {
         #if DEBUG
             print("ZeroConf: close")
         #endif
-        
+
         for (_, browser) in browsers {
             browser.unwatch()
         }
         browsers.removeAll()
     }
-    
+
     internal class Publisher: NSObject, NetServiceDelegate {
-        
+
         var nsp: NetService?
         var domain: String
         var type: String
@@ -141,7 +141,7 @@ import Foundation
         var txtRecord: [String: Data]?
         var callbackId: String
         var commandDelegate: CDVCommandDelegate?
-        
+
         init (withDomain domain: String, withType type: String, withName name: String, withPort port: Int, withTxtRecord txtRecord: [String: Data]?, withCallbackId callbackId: String) {
             self.domain = domain
             self.type = type
@@ -150,129 +150,129 @@ import Foundation
             self.txtRecord = txtRecord
             self.callbackId = callbackId
         }
-        
+
         func register() {
-            
+
             // Netservice
             let service = NetService(domain: domain, type: type , name: name, port: Int32(port))
             nsp = service
             service.delegate = self
-            
+
             if let record = txtRecord {
                 if record.count > 0 {
                     service.setTXTRecord(NetService.data(fromTXTRecord: record))
                 }
             }
-            
+
             commandDelegate?.run(inBackground: {
                 service.publish()
             })
-            
+
         }
-        
+
         func unregister() {
-            
+
             if let service = nsp {
                 service.stop()
             }
-            
+
         }
-        
+
         func destroy() {
-            
+
             if let service = nsp {
                 service.stop()
             }
-            
+
         }
-        
+
         @objc func netServiceDidPublish(_ netService: NetService) {
             #if DEBUG
                 print("ZeroConf: netService:didPublish:\(netService)")
             #endif
-            
+
             let service = ZeroConf.jsonifyService(netService)
-            
+
             let message: NSDictionary = NSDictionary(objects: ["registered", service], forKeys: ["action" as NSCopying, "service" as NSCopying])
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: message as! [AnyHashable: Any])
             commandDelegate?.send(pluginResult, callbackId: callbackId)
         }
-    
+
         @objc func netService(_ netService: NetService, didNotPublish errorDict: [String : NSNumber]) {
             #if DEBUG
                 print("ZeroConf: netService:didNotPublish:\(netService) \(errorDict)")
             #endif
-            
+
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR)
             commandDelegate?.send(pluginResult, callbackId: callbackId)
         }
-        
+
         @objc func netServiceDidStop(_ netService: NetService) {
             nsp = nil
             commandDelegate = nil
-            
+
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK)
             commandDelegate?.send(pluginResult, callbackId: callbackId)
         }
-        
+
     }
-    
+
     internal class Browser: NSObject, NetServiceDelegate, NetServiceBrowserDelegate {
-        
+
         var nsb: NetServiceBrowser?
         var domain: String
         var type: String
         var callbackId: String
         var services: [String: NetService] = [:]
         var commandDelegate: CDVCommandDelegate?
-        
+
         init (withDomain domain: String, withType type: String, withCallbackId callbackId: String) {
             self.domain = domain
             self.type = type
             self.callbackId = callbackId
         }
-        
+
         func watch() {
-            
+
              // Net service browser
             let browser = NetServiceBrowser()
             nsb = browser
             browser.delegate = self
-            
+
             commandDelegate?.run(inBackground: {
                 browser.searchForServices(ofType: self.type, inDomain: self.domain)
             })
-            
+
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
             pluginResult?.setKeepCallbackAs(true)
             commandDelegate?.send(pluginResult, callbackId: callbackId)
         }
-        
+
         func unwatch() {
-            
+
             if let service = nsb {
                 service.stop()
             }
-            
+
         }
-        
+
         func destroy() {
-            
+
             if let service = nsb {
                 service.stop()
             }
-            
+
         }
-        
+
         @objc func netServiceBrowser(_ browser: NetServiceBrowser, didNotSearch errorDict: [String : NSNumber]) {
             #if DEBUG
                 print("ZeroConf: netServiceBrowser:didNotSearch:\(netService) \(errorDict)")
             #endif
-            
+
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR)
             commandDelegate?.send(pluginResult, callbackId: callbackId)
         }
-        
+
         @objc func netServiceBrowser(_ netServiceBrowser: NetServiceBrowser,
                                      didFind netService: NetService,
                                      moreComing moreServicesComing: Bool) {
@@ -282,38 +282,38 @@ import Foundation
             netService.delegate = self
             netService.resolve(withTimeout: 5000)
             services[netService.name] = netService // keep strong reference to catch didResolveAddress
-            
+
             let service = ZeroConf.jsonifyService(netService)
-            
+
             let message: NSDictionary = NSDictionary(objects: ["added", service], forKeys: ["action" as NSCopying, "service" as NSCopying])
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: message as! [AnyHashable: Any])
             pluginResult?.setKeepCallbackAs(true)
             commandDelegate?.send(pluginResult, callbackId: callbackId)
         }
-        
+
         @objc func netServiceDidResolveAddress(_ netService: NetService) {
             #if DEBUG
                 print("ZeroConf: netService:didResolveAddress:\(netService)")
             #endif
-            
+
             let service = ZeroConf.jsonifyService(netService)
-            
+
             let message: NSDictionary = NSDictionary(objects: ["resolved", service], forKeys: ["action" as NSCopying, "service" as NSCopying])
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: message as! [AnyHashable: Any])
             pluginResult?.setKeepCallbackAs(true)
             commandDelegate?.send(pluginResult, callbackId: callbackId)
         }
-        
+
         @objc func netService(_ netService: NetService, didNotResolve errorDict: [String : NSNumber]) {
             #if DEBUG
                 print("ZeroConf: netService:didNotResolve:\(netService) \(errorDict)")
             #endif
-            
+
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR)
             pluginResult?.setKeepCallbackAs(true)
             commandDelegate?.send(pluginResult, callbackId: callbackId)
         }
-        
+
         @objc func netServiceBrowser(_ netServiceBrowser: NetServiceBrowser,
                                      didRemove netService: NetService,
                                      moreComing moreServicesComing: Bool) {
@@ -321,28 +321,28 @@ import Foundation
                 print("ZeroConf: netServiceBrowser:didRemoveService:\(netService)")
             #endif
             services.removeValue(forKey: netService.name)
-            
+
             let service = ZeroConf.jsonifyService(netService)
-            
+
             let message: NSDictionary = NSDictionary(objects: ["removed", service], forKeys: ["action" as NSCopying, "service" as NSCopying])
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: message as! [AnyHashable: Any])
             pluginResult?.setKeepCallbackAs(true)
             commandDelegate?.send(pluginResult, callbackId: callbackId)
         }
-        
+
         @objc func netServiceDidStop(_ netService: NetService) {
             nsb = nil
             services.removeAll()
             commandDelegate = nil
-            
+
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK)
             commandDelegate?.send(pluginResult, callbackId: callbackId)
         }
-        
+
     }
-    
+
     fileprivate static func jsonifyService(_ netService: NetService) -> NSDictionary {
-        
+
         var ipv4Addresses: [String] = []
         var ipv6Addresses: [String] = []
         for address in netService.addresses! {
@@ -358,11 +358,11 @@ import Foundation
                 }
             }
         }
-        
+
         if ipv6Addresses.count > 1 {
             ipv6Addresses = Array(Set(ipv6Addresses))
         }
-        
+
         var txtRecord: [String: String] = [:]
         if let txtRecordData = netService.txtRecordData() {
             let dict = NetService.dictionary(fromTXTRecord: txtRecordData)
@@ -370,19 +370,19 @@ import Foundation
                 txtRecord[key] = String(data: data, encoding:String.Encoding.utf8)
             }
         }
-        
+
         var hostName:String = ""
         if netService.hostName != nil {
             hostName = netService.hostName!
         }
-        
+
         let service: NSDictionary = NSDictionary(
             objects: [netService.domain, netService.type, netService.name, netService.port, hostName, ipv4Addresses, ipv6Addresses, txtRecord],
             forKeys: ["domain" as NSCopying, "type" as NSCopying, "name" as NSCopying, "port" as NSCopying, "hostname" as NSCopying, "ipv4Addresses" as NSCopying, "ipv6Addresses" as NSCopying, "txtRecord" as NSCopying])
-        
+
         return service
     }
-    
+
     fileprivate static func extractFamily(_ addressBytes:Data) -> Int? {
         let addr = (addressBytes as NSData).bytes.load(as: sockaddr.self)
         if (addr.sa_family == sa_family_t(AF_INET)) {
@@ -395,7 +395,7 @@ import Foundation
             return nil
         }
     }
-    
+
     fileprivate static func extractAddress(_ addressBytes:Data) -> String? {
         var addr = (addressBytes as NSData).bytes.load(as: sockaddr.self)
         var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
@@ -405,5 +405,5 @@ import Foundation
         }
         return nil
     }
-    
+
 }

--- a/src/ios/ZeroConf.swift
+++ b/src/ios/ZeroConf.swift
@@ -131,6 +131,30 @@ import Foundation
         browsers.removeAll()
     }
 
+    public func reInit(_ command: CDVInvokedUrlCommand) {
+        #if DEBUG
+            print("ZeroConf: reInit")
+        #endif
+
+        // Terminate
+        for (_, publisher) in publishers {
+            publisher.destroy()
+        }
+        publishers.removeAll()
+
+        for (_, browser) in browsers {
+            browser.destroy();
+        }
+        browsers.removeAll()
+
+        // init
+        publishers  = [:]
+        browsers = [:]
+
+        let pluginResult = CDVPluginResult(status:CDVCommandStatus_OK)
+        self.commandDelegate?.send(pluginResult, callbackId: command.callbackId)
+    }
+
     internal class Publisher: NSObject, NetServiceDelegate {
 
         var nsp: NetService?

--- a/www/zeroconf.js
+++ b/www/zeroconf.js
@@ -32,11 +32,11 @@ var ZeroConf = {
 
     close : function(success, failure) {
         return exec(success, failure, "ZeroConf", "close", []);
-    }
+    },
 
     init : function(success, failure) {
         return exec(success, failure, "ZeroConf", "initialize", []);
-    }
+    },
 
     destroy : function(success, failure) {
         return exec(success, failure, "ZeroConf", "onDestroy", []);

--- a/www/zeroconf.js
+++ b/www/zeroconf.js
@@ -34,12 +34,8 @@ var ZeroConf = {
         return exec(success, failure, "ZeroConf", "close", []);
     },
 
-    init : function(success, failure) {
-        return exec(success, failure, "ZeroConf", "init", []);
-    },
-
-    destroy : function(success, failure) {
-        return exec(success, failure, "ZeroConf", "destroy", []);
+    reInit : function(success, failure) {
+        return exec(success, failure, "ZeroConf", "reInit", []);
     }
 
 };

--- a/www/zeroconf.js
+++ b/www/zeroconf.js
@@ -35,11 +35,11 @@ var ZeroConf = {
     },
 
     init : function(success, failure) {
-        return exec(success, failure, "ZeroConf", "initialize", []);
+        return exec(success, failure, "ZeroConf", "init", []);
     },
 
     destroy : function(success, failure) {
-        return exec(success, failure, "ZeroConf", "onDestroy", []);
+        return exec(success, failure, "ZeroConf", "destroy", []);
     }
 
 };

--- a/www/zeroconf.js
+++ b/www/zeroconf.js
@@ -34,6 +34,14 @@ var ZeroConf = {
         return exec(success, failure, "ZeroConf", "close", []);
     }
 
+    init : function(success, failure) {
+        return exec(success, failure, "ZeroConf", "initialize", []);
+    }
+
+    destroy : function(success, failure) {
+        return exec(success, failure, "ZeroConf", "onDestroy", []);
+    }
+
 };
 
 module.exports = ZeroConf;


### PR DESCRIPTION
Adds a `reInit` action that wipes the previously instantiated contexts and restarts the plugin as if it were a fresh app boot.

If the Wifi network changes while the app is running, scan results do not update and errors are thrown for calls like `close()`. This can be avoided by reinstantiating the class, particularly for Android.

Resolves https://github.com/becvert/cordova-plugin-zeroconf/issues/51