### PR TITLE
Adding iOS callback for stop()

### DIFF
--- a/src/ios/ZeroConf.swift
+++ b/src/ios/ZeroConf.swift
@@ -86,6 +86,9 @@ import Foundation
             publisher.unregister()
         }
         publishers.removeAll()
+
+        let pluginResult = CDVPluginResult(status:CDVCommandStatus_OK)
+        self.commandDelegate?.send(pluginResult, callbackId: command.callbackId)
     }
 
     public func watch(_ command: CDVInvokedUrlCommand) {


### PR DESCRIPTION
Matches Android `stop()` callback behaviour for iOS.

Related: https://github.com/becvert/cordova-plugin-zeroconf/issues/52