### PR TITLE
Version 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.3.0] - 2017-11-23
+
+- [iOS] Added `close()` callback (per [#52](https://github.com/becvert/cordova-plugin-zeroconf/issues/52))
+- [iOS] Added `stop()` callback
+
 ## [1.2.9] - 2017-11-23
 
 - Added `reInit()` method to allow for runtime plugin reset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 ## [1.3.0] - 2017-11-23
 
+- Added `reInit()` method to allow for runtime plugin reset
 - [iOS] Added `close()` callback (per [#52](https://github.com/becvert/cordova-plugin-zeroconf/issues/52))
 - [iOS] Added `stop()` callback
-
-## [1.2.9] - 2017-11-23
-
-- Added `reInit()` method to allow for runtime plugin reset
 
 ## [1.2.8] - 2017-10-13
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-zeroconf",
-    "version": "1.2.9",
+    "version": "1.3.0",
     "description": "Cordova ZeroConf plugin",
     "cordova": {
         "id": "cordova-plugin-zeroconf",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-zeroconf"
-    version="1.2.9">
+    version="1.3.0">
 
     <name>ZeroConf</name>
     <description>ZeroConf plugin for Cordova/Phonegap</description>


### PR DESCRIPTION
- Minor version bump includes new `reInit()` method from [v1.2.9](https://github.com/becvert/cordova-plugin-zeroconf/pull/50)
- [iOS] Added `close()` callback ([#53](https://github.com/becvert/cordova-plugin-zeroconf/pull/53) as per [#52](https://github.com/becvert/cordova-plugin-zeroconf/issues/52))
- [iOS] Added `stop()` callback ([#55](https://github.com/becvert/cordova-plugin-zeroconf/pull/55))

## TODO

- [x] ~~Create & link `@ionic-native/zeroconf` PR~~ [added](https://github.com/ionic-team/ionic-native/pull/2144)
- [ ] Tag master after merging this PR
- [ ] `npm publish`