### PR TITLE
[iOS] updating cordova-plugin-add-swift-support dependency to 1.7.2

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,6 @@
         <source-file src="src/ios/Hostname.m"/>
     </platform>
     
-    <dependency id="cordova-plugin-add-swift-support" version="1.7.1"/>
+    <dependency id="cordova-plugin-add-swift-support" version="1.7.2"/>
 
 </plugin>


### PR DESCRIPTION
Haven't personally tested yet, but https://github.com/becvert/cordova-plugin-zeroconf/issues/62#issuecomment-377658614 reports success.

Resolves https://github.com/becvert/cordova-plugin-zeroconf/issues/62