### PR TITLE
JmDNS 3.5.4, Version 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.3.3] - 2018-04-13
+
+- [Android] updating JmDNS dependency to 3.5.4
+
 ## [1.3.2] - 2018-04-03
 
 - [Android] preventing crash (ConcurrentModificationException and RuntimeException)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-zeroconf",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "Cordova ZeroConf plugin",
     "cordova": {
         "id": "cordova-plugin-zeroconf",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-zeroconf"
-    version="1.3.2">
+    version="1.3.3">
 
     <name>ZeroConf</name>
     <description>ZeroConf plugin for Cordova/Phonegap</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,7 +25,7 @@
             </feature>
         </config-file>
         <source-file src="src/android/net/becvert/cordova/ZeroConf.java" target-dir="src/net/becvert/cordova" />
-        <framework src="org.jmdns:jmdns:3.5.3" />
+        <framework src="org.jmdns:jmdns:3.5.4" />
     </platform>
 
     <platform name="ios">


### PR DESCRIPTION
Updates JmDNS to 3.5.4 and bumps plugin version to 1.3.3.

Resolves https://github.com/becvert/cordova-plugin-zeroconf/issues/63