### PR TITLE
Version 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.4.2] - 2020-04-04
+
+- Added caret semver to `cordova-plugin-add-swift-support` #80
+- [iOS] Fixed handling of invalid TXTRecord keyValues that crash #86
+
 ## [1.4.1] - 2019-11-07
 
 - [iOS] updating cordova-plugin-add-swift-support dependency to 2.0.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-zeroconf",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "Cordova ZeroConf plugin",
     "cordova": {
         "id": "cordova-plugin-zeroconf",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-zeroconf"
-    version="1.4.1">
+    version="1.4.2">
 
     <name>ZeroConf</name>
     <description>ZeroConf plugin for Cordova/Phonegap</description>

--- a/src/ios/ZeroConf.swift
+++ b/src/ios/ZeroConf.swift
@@ -459,7 +459,7 @@ import Foundation
             case 2:
                 result[key] = String(keyValue[1])
             default:
-                fatalError()
+                fatalError("ZeroConf: Malformed or unexpected TXTRecord keyValue")
             }
         }
 


### PR DESCRIPTION
As per the changelog:

## [1.4.2] - 2020-04-04

- Added caret semver to `cordova-plugin-add-swift-support` #80
- [iOS] Fixed handling of invalid TXTRecord keyValues that crash #86
