### PR TITLE
remove depenency on swift plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,6 @@
     "bugs": {
         "url": "https://github.com/becvert/cordova-plugin-zeroconf/issues"
     },
-    "homepage": "https://github.com/becvert/cordova-plugin-zeroconf"
+    "homepage": "https://github.com/becvert/cordova-plugin-zeroconf",
+    "types": "./types/index.d.ts"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,6 +36,7 @@
             <feature name="ZeroConf">
                 <param name="ios-package" value="ZeroConf"/>
             </feature>
+            <preference name="SwiftVersion" value="4.0" />
         </config-file>
         <header-file src="src/ios/ZeroConf-Bridging-Header.h"  type="BridgingHeader" />
         <source-file src="src/ios/ZeroConf.swift"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,11 +37,10 @@
                 <param name="ios-package" value="ZeroConf"/>
             </feature>
         </config-file>
-        <header-file src="src/ios/ZeroConf-Bridging-Header.h"/>
+        <header-file src="src/ios/ZeroConf-Bridging-Header.h"  type="BridgingHeader" />
         <source-file src="src/ios/ZeroConf.swift"/>
         <header-file src="src/ios/Hostname.h"/>
         <source-file src="src/ios/Hostname.m"/>
     </platform>
 
-    <dependency id="cordova-plugin-add-swift-support" version="^2.0.2"/>
 </plugin>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,142 @@
+// Type definitions for Apache Cordova Zeroconf (mDNS) plugin
+// Project: https://github.com/becvert/cordova-plugin-zeroconf
+
+declare namespace ZeroConfPlugin {
+    interface TxtRecord {
+        [key: string]: string
+    }
+    
+    /* service : {
+        'domain' : 'local.',
+        'type' : '_http._tcp.',
+        'name': 'Becvert\'s iPad',
+        'port' : 80,
+        'hostname' : 'ipad-of-becvert.local',
+        'ipv4Addresses' : [ '192.168.1.125' ], 
+        'ipv6Addresses' : [ '2001:0:5ef5:79fb:10cb:1dbf:3f57:feb0' ],
+        'txtRecord' : {
+            'foo' : 'bar'
+    } */
+    interface Service {
+        domain: string;
+        type: string;
+        name: string;
+        port: number;
+        hostname: string;
+        ipv4Addresses: Array<string>;
+        ipv6Addresses: Array<string>;
+        txtRecord: TxtRecord;
+    }
+    
+    interface Result {
+        /** added, resolved, registered */
+        action: string;
+        service: Service;
+    }
+    
+    interface ZeroConf {
+        /** This plugin allows you to browse and publish ZeroConf/Bonjour/mDNS services from applications developed using PhoneGap/Cordova 3.0 or newer and Ionic's Capacitor. */
+    
+        /** any, ipv6 or ipv4 */
+        registerAddressFamily: string;
+        /** any, ipv6 or ipv4 */
+        watchAddressFamily: string;
+    
+        /**
+         * Returns this device's hostname.
+         * @param successCallback   The callback that is called when the plugin returns the hostname.
+         * @param errorCallback     A callback that is called when errors happen.
+         */
+        getHostname(
+            successCallback: (hostname: string) => void,
+            errorCallback?: (error: string) => void): void;
+    
+        /**
+         * Publishes a new service.
+         * @param type 
+         * @param domain
+         * @param name
+         * @param port
+         * @param txtRecord
+         * @param successCallback   The callback that is called when the plugin completes successully.
+         * @param errorCallback     A callback that is called when errors happen.
+         */
+        register(
+            type: string,
+            domain: string,
+            name: string,
+            port: number,
+            txtRecord: TxtRecord,
+            successCallback: (result: Result) => void,
+            errorCallback?: (error: string) => void): void;
+    
+        /**
+        * Unregisters a service.
+        * @param type 
+        * @param domain
+        * @param name
+        * @param successCallback   The callback that is called when the plugin completes successully.
+        * @param errorCallback     A callback that is called when errors happen.
+        */
+        unregister(
+            type: string,
+            domain: string,
+            name: string,
+            successCallback: () => void,
+            errorCallback?: (error: string) => void): void;
+    
+        /**
+        * Unregisters all published services.
+        * @param successCallback   The callback that is called when the plugin completes successully.
+        * @param errorCallback     A callback that is called when errors happen.
+        */
+        stop(
+            successCallback: () => void,
+            errorCallback?: (error: string) => void): void;
+    
+        /**
+        * Starts watching for services of the specified type.
+        * @param type 
+        * @param domain
+        * @param successCallback   The callback that is called when the plugin completes successully.  Also called whenever a new service is discovered or resolved.
+        * @param errorCallback     A callback that is called when errors happen.
+        */
+        watch(
+            type: string,
+            domain: string,
+            successCallback: (result: Result) => void,
+            errorCallback?: (error: string) => void): void;
+    
+        /**
+        * Stops watching for services of the specified type.
+        * @param type 
+        * @param domain
+        * @param successCallback   The callback that is called when the plugin completes successully.  Also called whenever a new service is discovered or resolved.
+        * @param errorCallback     A callback that is called when errors happen.
+        */
+        unwatch(
+            type: string,
+            domain: string,
+            successCallback: () => void,
+            errorCallback?: (error: string) => void): void;
+    
+    
+        /**
+        * Closes the service browser and stops watching.
+        * @param successCallback   The callback that is called when the plugin completes successully.
+        * @param errorCallback     A callback that is called when errors happen.
+        */
+        close(
+            successCallback: () => void,
+            errorCallback?: (error: string) => void): void;
+    
+        /**
+        * Re-initializes the entire plugin, which resets the browsers and services. Use this if the WiFi network has changed while the app is running.
+        * @param successCallback   The callback that is called when the plugin completes successully.
+        * @param errorCallback     A callback that is called when errors happen.
+        */
+        reInit(
+            successCallback: () => void,
+            errorCallback?: (error: string) => void): void;
+    }
+}


### PR DESCRIPTION
see #101 

I tested this and it works on iOS.  I don't think it should affect Android at all, but I'll check it.

But I did get the error 
`error: Value for SWIFT_VERSION cannot be empty.`  but then I manually set the Swift Version in XCode and it worked.  Not sure why `<preference name="SwiftVersion" value="4.0" />` is not taking effect.  Maybe a bug in cordova?